### PR TITLE
the ciissversion field is mandatory

### DIFF
--- a/torcontactinfo.py
+++ b/torcontactinfo.py
@@ -295,6 +295,11 @@ class TorContactInfoParser(object):
         pass
 
     def parse(self, value, raise_exception_on_invalid_value=False):
+        
+        # the ciissversion field is mandatory
+        if not 'ciissversion:' in value:
+            return None
+        
         result = {}
         parts = value.split(" ")
         for p in parts:


### PR DESCRIPTION
this change will cause empty results if
there is no ciissversion field. Maybe it helps also with
performance.