### PR TITLE
v0.8.0 - Privex Overhaul - Argument parsing, subcommands, pretty printing, and more :)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,132 @@
-# torcontactinfoparser
+# Tor Contact Info Parser - A tool/Python Class for parsing Tor ContactInfo Information Sharing v2 specification contacts
+
+![Screenshot of Tor Contact Info Parser in action](https://i.imgur.com/hBfppeR.png)
 
 Written by Eran Sandler ([@erans](https://twitter.com/erans)) &copy; 2018
 
+Turned into a proper command-line tool with sub-commands and flags by @Someguy123 at [Privex Inc.](https://www.privex.io) [(github)](https://github.com/PrivexInc) &copy; 2021
+
 This is a parser for the
 [Tor ContactInfo Information Sharing Specification](https://nusenu.github.io/ContactInfo-Information-Sharing-Specification/) (version 2).
+
 The parser can parse the ContactInfo field of Tor relays based on the specification.
+
+Official Repo: <https://github.com/erans/torcontactinfoparser>
+
+Privex Fork: <https://github.com/Privex/torcontactinfoparser>
+
+## Requirements
+
+- Python 3.6 or newer (Tested on Python 3.9)
+- A terminal to run the script with
+- Should work on any operating system which can run Python, and can install Python packages - including Linux, macOS, BSDs, and Windows
+- Info about optional Python package dependencies:
+  - The `parse` sub-command should be usable from any standard Python 3.6+ installation, as it's dependency free. However, for nicer pretty printing,
+    you may want to install the `rich` PyPi package using `pip3` (included in the `requirements.txt`).
+  - The `scan` sub-command requires the Python HTTP Requests library `requests` - and can also take advantage of `rich` if installed.
+
+## Quickstart
+
+```sh
+# Clone the repo
+git clone https://github.com/erans/torcontactinfoparser.git
+cd torcontactinfoparser
+# NOTE: You don't need any external packages to use the 'parse' command, however, you should install the optional dependencies
+# from requirements.txt for the best user experience.
+pip3 install -U -r requirements.txt
+
+# The easiest way to use the parse command, is simply to pass the contact string as positional arguments. You can specify it as either
+# a single string in the first argument:
+./torcontactinfo.py parse "Privex Inc. email:noc[]privex.io url:https://www.privex.io proof:uri-rsa pgp:288DD1632F6E8951 keybase:privexinc twitter:PrivexInc"
+# Or you can split it across multiple arguments if you need/want to do so:
+./torcontactinfo.py parse Privex Inc. "email:noc[]privex.io url:https://www.privex.io" \
+    "proof:uri-rsa pgp:288DD1632F6E8951" keybase:privexinc twitter:PrivexInc
+
+# You can also pipe a contact string into the parse command.
+echo "Privex Inc. email:noc[]privex.io url:https://www.privex.io" \
+     "proof:uri-rsa pgp:288DD1632F6E8951 keybase:privexinc twitter:PrivexInc" | ./torcontactinfo.py parse
+
+# The scan command is primarily used by @nusenu for populating the contact details in some of their public services,
+# but you can use it too, if you have a use for it :)
+./torcontactinfo.py scan
+
+# For backwards compatibility, the scan command is ran by default if you don't pass any arguments
+./torcontactinfo.py
+
+# To enable pretty printing for the scan command, simply add the argument '-p'
+./torcontactinfo.py scan -p
+```
+
+## Examples
+
+### Using the `parse` subcommand
+
+```sh
+# Using 'parse', you can parse an arbitrary ContactInfo string, and it will output the parsed result
+# with pretty printing by default.
+
+./torcontactinfo.py parse "contact Privex Inc. email:noc[]privex.io url:https://www.privex.io " \
+        "proof:uri-rsa pgp:288DD1632F6E8951 keybase:privexinc twitter:PrivexInc hoster:www.privex.io " \
+        "uplinkbw:500 memory:4096 virtualization:kvm btc:bc1qpst9uscvd8rpjjhzz9rau3trylh6e0wh76qrlhw3q9nj89ua728sn3t6a2 " \
+        "xmr:89tukP3wfpH4FZAmC1D2GfArWwfPTz8Ap46NZc54Vyhy9YxEUYoFQ7HGQ74LrCMQTD3zxvwM1ewmGjH9WVmeffwR72m1Pps"
+
+    {
+        'email': 'noc@privex.io',
+        'url': 'https://www.privex.io',
+        'proof': 'uri-rsa',
+        'pgp': None,
+        'keybase': 'privexinc',
+        'twitter': 'PrivexInc',
+        'hoster': 'www.privex.io',
+        'uplinkbw': '500',
+        'memory': '4096',
+        'virtualization': 'kvm',
+        'btc': 'bc1qpst9uscvd8rpjjhzz9rau3trylh6e0wh76qrlhw3q9nj89ua728sn3t6a2',
+        'xmr': '89tukP3wfpH4FZAmC1D2GfArWwfPTz8Ap46NZc54Vyhy9YxEUYoFQ7HGQ74LrCMQTD3zxvwM1ewmGjH9WVmeffwR72m1Pps'
+    }
+
+# You can also pipe a contact string into 'parse', and it will work just the same.
+
+echo "Privex Inc. email:noc[]privex.io url:https://www.privex.io proof:uri-rsa pgp:288DD1632F6E8951 keybase:privexinc twitter:PrivexInc" | ./torcontactinfo.py parse
+
+    {'email': 'noc@privex.io', 'url': 'https://www.privex.io', 'proof': 'uri-rsa', 'pgp': None, 'keybase': 'privexinc', 'twitter': 'PrivexInc'}
+
+# If you need real JSON outputted, rather than Python dict-style output, you can pass -j to either 'parse' or 'scan'
+
+./torcontactinfo.py parse -j "Privex Inc. email:noc[]privex.io url:https://www.privex.io proof:uri-rsa pgp:288DD1632F6E8951 keybase:privexinc twitter:PrivexInc"
+
+    {
+        "email": "noc@privex.io",
+        "url": "https://www.privex.io",
+        "proof": "uri-rsa",
+        "pgp": null,
+        "keybase": "privexinc",
+        "twitter": "PrivexInc"
+    }
+
+# You can use '-np' to disable pretty printing for 'parse' - you can combine it with '-j' to get flat, plain JSON.
+
+./torcontactinfo.py parse -np -j "Privex Inc. email:noc[]privex.io url:https://www.privex.io proof:uri-rsa pgp:288DD1632F6E8951 keybase:privexinc twitter:PrivexInc"
+
+    {"email": "noc@privex.io", "url": "https://www.privex.io", "proof": "uri-rsa", "pgp": null, "keybase": "privexinc", "twitter": "PrivexInc"}
+
+```
+
+### Using the `scan` subcommand
+
+```sh
+# 'scan' is the original behaviour of this script. It iterates over the data 
+# from https://onionoo.torproject.org/details , parses each contact, and prints it as Python dict-style JSON.
+./torcontactinfo.py scan
+
+# Same as previous. With no arguments, it's equivalent to running 'scan'.
+./torcontactinfo.py
+
+# If you pass '-p' after scan, it will enable pretty printing. For best pretty printing,
+# make sure you have 'rich' installed from pypi.
+./torcontactinfo.py scan -p
+
+# If you need real JSON with double quotes, rather than Python dict-style JSON, you can
+# use the '-j' flag to enable "real JSON" mode (you can combine with '-p' if you want pretty printed real json)
+./torcontactinfo.py scan -j
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests
+rich
+

--- a/torcontactinfo.py
+++ b/torcontactinfo.py
@@ -1,4 +1,37 @@
+#!/usr/bin/env python3
+"""
+Tor Contact Info Parser - A tool/Python Class for parsing Tor ContactInfo Information Sharing v2 specification contacts
+Written by Eran Sandler  (https://twitter.com/erans) (C) 2018
+
+Turned into a proper command-line tool with sub-commands and flags by @Someguy123 at Privex Inc. (C) 2021
+(https://www.privex.io) (https://github.com/PrivexInc) 
+
+This is a parser for the Tor ContactInfo Information Sharing Specification v2 (https://nusenu.github.io/ContactInfo-Information-Sharing-Specification/).
+
+The parser can parse the ContactInfo field of Tor relays based on the specification.
+
+Official Repo: https://github.com/erans/torcontactinfoparser
+Privex Fork: https://github.com/Privex/torcontactinfoparser
+
+Released under the MIT License.
+"""
+import argparse
 import re
+import sys
+import json
+import textwrap
+try:
+    from rich import print as rprint
+    HAS_RICH = True
+except ImportError:
+    def rprint(value='', *args, **kwargs):
+        if value not in [None, False, True] and isinstance(value, (dict, list, set, tuple)):
+            value = json.dumps(value, indent=4)
+        return print(value, *args, **kwargs)
+    # rprint = print
+    HAS_RICH = False
+
+from argparse import ArgumentParser
 
 class TorContactInfoParser(object):
     def _parse_string_value(self, value, min_length, max_length, valid_chars, raise_exception=False, field_name=None):
@@ -294,30 +327,56 @@ class TorContactInfoParser(object):
     def __init__(self):
         pass
 
-    def parse(self, value, raise_exception_on_invalid_value=False):
+    def parse(self, value: str, raise_exception_on_invalid_value=False) -> dict:
         result = {}
         parts = value.split(" ")
         for p in parts:
             field_parts = p.split(":", 1)
-            if len(field_parts) > 1:
-                if field_parts[0] in self._supported_fields_parsers:
-                    field_parser = self._supported_fields_parsers[field_parts[0]]
-                    if field_parser is None:
-                        result[field_parts[0]] = field_parts[1]
-                    else:
-                        if callable(field_parser):
-                            value = field_parser(self, field_parts[1])
-                        else:
-                            field_parser["args"]["field_name"] = field_parts[0]
-                            field_parser["args"]["value"] = field_parts[1]
-                            field_parser["args"]["raise_exception"] = raise_exception_on_invalid_value
+            if len(field_parts) <= 1:
+                continue
+            name, data = field_parts
+            if name in self._supported_fields_parsers:
+                field_parser = self._supported_fields_parsers[name]
+                if field_parser is None:
+                    result[name] = data
+                    continue
+                if callable(field_parser):
+                    value = field_parser(self, data)
+                else:
+                    field_parser["args"]["field_name"] = name
+                    field_parser["args"]["value"] = data
+                    field_parser["args"]["raise_exception"] = raise_exception_on_invalid_value
 
-                            value = field_parser["fn"](self, **field_parser["args"])
-                        result[field_parts[0]] = value
+                    value = field_parser["fn"](self, **field_parser["args"])
+                result[name] = value
 
         return result
 
-if __name__ == "__main__":
+def cmd_parse(opts: argparse.Namespace):
+    """
+    ArgParser function for parsing a single ContactInfo string, and outputting it as JSON (or python-style dict's)
+    """
+
+    if opts.contact is None or len(opts.contact) == 0 or opts.contact[0] == '-':
+        contact = sys.stdin.read()
+    else:
+        contact = ' '.join(opts.contact).strip()
+
+    tparser = TorContactInfoParser()
+    res = tparser.parse(contact)
+    if not opts.pretty:
+        return print(json.dumps(res))
+    if opts.json: res = json.dumps(res, indent=4) if opts.pretty else json.dumps(res)
+    # if not HAS_RICH: res = json.dumps(res, indent=4)
+    rprint(res)
+
+    
+
+def cmd_scan(opts: argparse.Namespace):
+    """
+    ArgParser function for scanning all ContactInfo strings from ``https://onionoo.torproject.org/details`` ,
+    and outputting each one as a Python-style Dict, or JSON.
+    """
     import requests
 
     parser = TorContactInfoParser()
@@ -325,7 +384,103 @@ if __name__ == "__main__":
     data = requests.get("https://onionoo.torproject.org/details").json()
     for r in data["relays"]:
         contact = r.get("contact", None)
-        if contact:
-            result = parser.parse(contact, False)
-            if len(result) > 0:
+        if not contact: continue
+        result = parser.parse(contact, False)
+        if len(result) > 0:
+            if opts.json: result = json.dumps(result, indent=4) if opts.pretty else json.dumps(result)
+            if opts.pretty:
+                rprint(result)
+            else:
                 print(result)
+
+
+def main():
+    cparser = ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=textwrap.dedent(f"""
+    Examples:
+
+        # 'scan' is the original behaviour of this script. It iterates over the data 
+        # from https://onionoo.torproject.org/details , parses each contact, and prints it as Python dict-style JSON.
+        {sys.argv[0]} scan
+        
+        # Same as previous. With no arguments, it's equivalent to running 'scan'.
+        {sys.argv[0]}
+
+        # If you pass '-p' after scan, it will enable pretty printing. For best pretty printing,
+        # make sure you have 'rich' installed from pypi.
+        {sys.argv[0]} scan -p
+
+        # If you need real JSON with double quotes, rather than Python dict-style JSON, you can
+        # use the '-j' flag to enable "real JSON" mode (you can combine with '-p' if you want pretty printed real json)
+        {sys.argv[0]} scan -j
+
+        # Using 'parse', you can parse an arbitrary ContactInfo string, and it will output the parsed result
+        # with pretty printing by default.
+
+        {sys.argv[0]} parse "contact Privex Inc. email:noc[]privex.io url:https://www.privex.io " \\
+                "proof:uri-rsa pgp:288DD1632F6E8951 keybase:privexinc twitter:PrivexInc hoster:www.privex.io " \\
+                "uplinkbw:500 memory:4096 virtualization:kvm btc:bc1qpst9uscvd8rpjjhzz9rau3trylh6e0wh76qrlhw3q9nj89ua728sn3t6a2 " \\
+                "xmr:89tukP3wfpH4FZAmC1D2GfArWwfPTz8Ap46NZc54Vyhy9YxEUYoFQ7HGQ74LrCMQTD3zxvwM1ewmGjH9WVmeffwR72m1Pps"
+        
+            {{
+                'email': 'noc@privex.io',
+                'url': 'https://www.privex.io',
+                'proof': 'uri-rsa',
+                'pgp': None,
+                'keybase': 'privexinc',
+                'twitter': 'PrivexInc',
+                'hoster': 'www.privex.io',
+                'uplinkbw': '500',
+                'memory': '4096',
+                'virtualization': 'kvm',
+                'btc': 'bc1qpst9uscvd8rpjjhzz9rau3trylh6e0wh76qrlhw3q9nj89ua728sn3t6a2',
+                'xmr': '89tukP3wfpH4FZAmC1D2GfArWwfPTz8Ap46NZc54Vyhy9YxEUYoFQ7HGQ74LrCMQTD3zxvwM1ewmGjH9WVmeffwR72m1Pps'
+            }}
+        
+        # You can also pipe a contact string into 'parse', and it will work just the same.
+
+        echo "Privex Inc. email:noc[]privex.io url:https://www.privex.io proof:uri-rsa pgp:288DD1632F6E8951 keybase:privexinc twitter:PrivexInc" | {sys.argv[0]} parse
+        {{'email': 'noc@privex.io', 'url': 'https://www.privex.io', 'proof': 'uri-rsa', 'pgp': None, 'keybase': 'privexinc', 'twitter': 'PrivexInc\n'}}
+
+        # If you need real JSON outputted, rather than Python dict-style output, you can pass -j to either 'parse' or 'scan'
+
+        {sys.argv[0]} parse -j "Privex Inc. email:noc[]privex.io url:https://www.privex.io proof:uri-rsa pgp:288DD1632F6E8951 keybase:privexinc twitter:PrivexInc"
+            {{
+                "email": "noc@privex.io",
+                "url": "https://www.privex.io",
+                "proof": "uri-rsa",
+                "pgp": null,
+                "keybase": "privexinc",
+                "twitter": "PrivexInc"
+            }}
+
+        # You can use '-np' to disable pretty printing for 'parse' - you can combine it with '-j' to get flat, plain JSON.
+
+        {sys.argv[0]} parse -np -j "Privex Inc. email:noc[]privex.io url:https://www.privex.io proof:uri-rsa pgp:288DD1632F6E8951 keybase:privexinc twitter:PrivexInc"
+            {{"email": "noc@privex.io", "url": "https://www.privex.io", "proof": "uri-rsa", "pgp": null, "keybase": "privexinc", "twitter": "PrivexInc"}}
+    """))
+    cparser.set_defaults(func=cmd_scan, json=False, pretty=False)
+    subparse = cparser.add_subparsers()
+    subparse.required = False
+    sp_parse = subparse.add_parser('parse', help="Parse a single contact string, either as an argument, or piped into stdin")
+    sp_parse.add_argument('contact', nargs='*')
+    sp_parse.add_argument('-np', '--no-pretty', action='store_false', default=True, dest='pretty', help="Disable pretty printing JSON")
+    sp_parse.add_argument('-j', '--json', action='store_true', default=False, dest='json', help="Output real JSON, not Python dict format.")
+    sp_parse.set_defaults(func=cmd_parse)
+
+    sp_scan = subparse.add_parser('scan', help="Parse all contacts from https://onionoo.torproject.org/details")
+    sp_scan.add_argument('-p', action='store_true', default=False, dest='pretty', help="Enable pretty printing JSON")
+    sp_scan.add_argument('-j', '--json', action='store_true', default=False, dest='json', help="Output real JSON, not Python dict format.")
+
+    sp_scan.set_defaults(func=cmd_scan)
+
+    args = cparser.parse_args()
+
+    args.func(args)
+
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
![Screenshot of Tor Contact Info Parser in action](https://i.imgur.com/hBfppeR.png)

I've made a massive overhaul of the script, while making sure to retain backwards compatibility, such as making the API contact dumping (now known as the sub-command `scan`) run when the script is ran without arguments, and ensuring the `scan` command still outputs in Python Dict dumps, instead of standard JSON (but you can make it output standard JSON simply by passing `-j`).

I was trying to verify the v2 contactinfo on our Tor nodes, and I found this project. I saw it wasn't very fleshed out, so I've cleaned it up, added features, made it more user friendly, padded out the README, added a requirements file, and more :)

Psst @nusenu - I hope this helps you too, with your Tor node info tools 👍 

- Fleshed out the `README.md` with a quickstart, examples, requirements, a screenshot, and other general improvements.

- Added a `requirements.txt` file so that users can easily install the two dependencies `requests` and `rich` without having to read the code,
  or run the script to figure out they need them.

- Added `#!/usr/bin/env python3` shebang so that the file can be ran as an executable on UNIX-based systems such as Linux, Mac, and BSD.

- Added a comment block to the top of the Python file, so that anyone who makes a copy of just the Python file, actually knows
  where it came from, what it does, and what license it's under.

- Created `main` function, which uses `argparse.ArgumentParser` to parse command line arguments, thus providing subcommands, flags,
  and CLI arguments.

- Moved the code from the `__name__ == '__main__'` section into `cmd_scan` so that it's a self-contained sub-command

- Created new `cmd_parse` function, which uses the `TorContactInfoParser` class to parse arbitrary ContactInfo strings, whether
  they're passed on the CLI arguments, or piped in via stdin.

- `TorContactInfoParser.parse`
  - Refactored `TorContactInfoParser.parse` method to reduce over-use of `if/else`, so that the code is easier to read
  - Split `field_parts` into `field` and `data`, so that there's no need to use unclear `field_parts[0]` / `field_parts[1]`
  - Added type hints to the parameters and return type.

- Added support for pretty printing the output of scan/parse using the `rich` library. It uses an ImportError try/except
  so that it can safely fallback to a simple print wrapper command, so that the program still works fine without `rich`.

- Added detailed help text for the command, which can be shown by running `./torcontactinfo.py -h` or `--help`

- Added capability for `parse`/`scan` to output actual standard JSON with double quoting by passing the argument `-j`

- Pretty printing is disabled for `scan` by default, to avoid breaking any pre-existing systems that depend on the
  original format of it's output. You can enable pretty printing on-demand by passing `-p` to the scan command.

- Pretty printing is enabled by default for `parse`, but can be disabled using the argument `-np`

- The program automatically runs the `scan` sub-command if you don't specify any arguments, which ensures that the script
  should be backwards compatible with any previous automation that may call it.

- Probably some other nice stuff that I forgot to mention :)